### PR TITLE
Replace strings/code; Optional include paths for replacements; Alias React JSX runtime

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -170,10 +170,104 @@ Its value is one of:
 
 The following optional task properties perform various substitutions.
 
-- `alias` - Map import module name to target module name or file path
-- `importToGlobal` - Map import module name to global variable name; supports dynamic name such as `@example/*`, for which a function should be given that takes the module name and returns the variable name
-- `globalToImport` - Map global variable name to import module name
-- `replaceStrings` - Map string to another string
+##### alias
+
+Using `alias` you can map an import module name to target another module name or file path. This uses rollup's [alias](https://github.com/rollup/plugins/tree/master/packages/alias#custom-resolvers) plugin under the hood.
+
+Here's an example use of the `alias` parameter:
+
+```js
+module.exports = {
+  build: [
+    {
+      src: 'src/index.js',
+      dest: 'build/app.min.js',
+      alias: [
+        {
+          find: 'src',
+          replacement: path.resolve(projectRootDir, 'src')
+        }
+      ]
+    },
+  // ...
+}
+```
+
+##### importToGlobal
+
+Using `importToGlobal` you can map import module names to global variable names. It supports dynamic names such as `@example/*`, for which a function should be given that takes the module name and returns the variable name:
+
+```js
+module.exports = {
+  build: [
+    {
+      src: 'src/index.js',
+      dest: 'build/app.min.js',
+      importToGlobal: {
+        '@my-namespace/*': 'myGlobalVar.*'
+      }
+    },
+  // ...
+}
+```
+
+In WordPress mode Roller imports `@wordpress/*` into the global variable `wp.*`.
+
+##### globalToImport
+
+Using `globalToImport` would be a reverse situation of using `importToGlobal`. Here you can map a global variable name to an import module name. This uses Rollup's [inject](https://github.com/rollup/plugins/tree/master/packages/inject) plugin under the hood.
+
+```js
+module.exports = {
+  build: [
+    {
+      src: 'src/index.js',
+      dest: 'build/app.min.js',
+      globalToImport: {
+        // import { Promise } from 'es6-promise'
+        Promise: [ 'es6-promise', 'Promise' ],
+
+        // import { Promise as P } from 'es6-promise'
+        P: [ 'es6-promise', 'Promise' ],
+
+        // import $ from 'jquery'
+        $: 'jquery',
+
+        // import * as fs from 'fs'
+        fs: [ 'fs', '*' ],
+
+        // use a local module instead of a third-party one
+        'Object.assign': path.resolve( 'src/helpers/object-assign.js' ),
+      }
+    },
+  // ...
+}
+```
+
+##### replaceStrings
+
+Using `replaceStrings` you can [map a string to another string](https://github.com/rollup/plugins/tree/master/packages/replace) during script processing. It can be handy for replacing placeholders with actual variables.
+
+```js
+module.exports = {
+  build: [
+    {
+      src: 'src/index.js',
+      dest: 'build/app.min.js',
+      replaceStrings: {
+        'process.env.NODE_ENV': JSON.stringify('production'),
+        __buildDate__: () => JSON.stringify(new Date()),
+        __buildVersion: 15
+      },
+      replaceInclude: [ // By default all files are included, but you can specify include patterns or names
+        path.resolve( 'some/path/' ),
+        /\.[jt]sx?$/,
+        /node_modules/
+      ]
+    },
+  // ...
+}
+```
 
 #### HTML
 

--- a/readme.md
+++ b/readme.md
@@ -246,7 +246,7 @@ export default {
 
 ##### replaceStrings
 
-Using `replaceStrings` you can [map a string to another string](https://github.com/rollup/plugins/tree/master/packages/replace) during script processing. It can be handy for replacing placeholders with actual variables.
+Using `replaceStrings` you can [map a string to another string](https://github.com/rollup/plugins/tree/master/packages/replace) during script processing. It can be handy for replacing placeholders with actual values at build time.
 
 ```js
 export default {
@@ -257,15 +257,73 @@ export default {
       replaceStrings: {
         'process.env.NODE_ENV': 'production',
         __buildDate__: () => new Date(),
-        __buildVersion: 15
+        __buildVersion__: 15
       },
-      replaceInclude: [ // By default all files are included, but you can specify include patterns or names
+      replaceInclude: [
         path.resolve( 'some/path/' ),
         /\.[jt]sx?$/,
         /node_modules/
       ]
     },
   // ...
+}
+```
+
+The given values are encoded with `JSON.stringify()`.
+
+By default, the string replacement applies to all files. Optionally use `replaceInclude` to specify an array of include file patterns.
+
+The above replacements will convert this:
+
+```js
+const buildTimeValues = {
+  date: __buildDate__,
+  version: __buildVersion__
+}
+```
+
+..into..
+
+```js
+const buildTimeValues = {
+  date: "2025-09-16T15:26:54.280Z",
+  version: 15
+}
+```
+
+##### replaceCode
+
+This is similar to `replaceStrings`, but it replaces the source with literal code instead of JSON string. It's useful for replacing a placeholder with code that evaluates to a value at run time.
+
+To demonstrate the difference:
+
+```js
+{
+  replaceCode: {
+    'process.env.NODE_ENV': '"production"'
+    __currentDate__: 'new Date()'
+    __currentVersion__: '15'
+  }
+}
+```
+
+The date constant will be replaced by the given code to get a new `Date` instance, instead of a string value evaluated at build time. The version constant will be replaced by the code `15`.
+
+The above replacements will convert this:
+
+```js
+const runTimeValues = {
+  date: __currentDate__,
+  version: __currentVersion__
+}
+```
+
+..into..
+
+```js
+const runTimeValues = {
+  date: new Date(),
+  version: 15
 }
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -119,7 +119,7 @@ Create a file called `tangible.config.js` in your project folder.
 Example:
 
 ```js
-module.exports = {
+export default {
   build: [
     {
       src: 'src/index.js',
@@ -177,7 +177,7 @@ Using `alias` you can map an import module name to target another module name or
 Here's an example use of the `alias` parameter:
 
 ```js
-module.exports = {
+export default {
   build: [
     {
       src: 'src/index.js',
@@ -198,7 +198,7 @@ module.exports = {
 Using `importToGlobal` you can map import module names to global variable names. It supports dynamic names such as `@example/*`, for which a function should be given that takes the module name and returns the variable name:
 
 ```js
-module.exports = {
+export default {
   build: [
     {
       src: 'src/index.js',
@@ -218,7 +218,7 @@ In WordPress mode Roller imports `@wordpress/*` into the global variable `wp.*`.
 Using `globalToImport` would be a reverse situation of using `importToGlobal`. Here you can map a global variable name to an import module name. This uses Rollup's [inject](https://github.com/rollup/plugins/tree/master/packages/inject) plugin under the hood.
 
 ```js
-module.exports = {
+export default {
   build: [
     {
       src: 'src/index.js',
@@ -249,7 +249,7 @@ module.exports = {
 Using `replaceStrings` you can [map a string to another string](https://github.com/rollup/plugins/tree/master/packages/replace) during script processing. It can be handy for replacing placeholders with actual variables.
 
 ```js
-module.exports = {
+export default {
   build: [
     {
       src: 'src/index.js',

--- a/readme.md
+++ b/readme.md
@@ -255,8 +255,8 @@ export default {
       src: 'src/index.js',
       dest: 'build/app.min.js',
       replaceStrings: {
-        'process.env.NODE_ENV': JSON.stringify('production'),
-        __buildDate__: () => JSON.stringify(new Date()),
+        'process.env.NODE_ENV': 'production',
+        __buildDate__: () => new Date(),
         __buildVersion: 15
       },
       replaceInclude: [ // By default all files are included, but you can specify include patterns or names

--- a/task/js.js
+++ b/task/js.js
@@ -95,6 +95,10 @@ export default function createOptionsForTaskType(config, task) {
     }
   }
 
+  if (task.replaceCode) {
+    Object.assign(values, task.replaceCode)
+  }
+
   const replaceStrings = {
     // Silence warning from plugin about default value (true) in next version
     preventAssignment: true,

--- a/task/js.js
+++ b/task/js.js
@@ -91,15 +91,18 @@ export default function createOptionsForTaskType(config, task) {
       values[key] =
         task.replaceStrings[key] instanceof Function
           ? () => JSON.stringify(task.replaceStrings[key]())
-          : task.replaceStrings[key]
+          : JSON.stringify(task.replaceStrings[key])
     }
   }
 
   const replaceStrings = {
     // Silence warning from plugin about default value (true) in next version
-    include: task.replaceInclude,
     preventAssignment: true,
     values,
+  }
+
+  if ( typeof task.replaceInclude !== 'undefined' ) {
+    replaceStrings.include = task.replaceInclude;
   }
 
   // React
@@ -147,6 +150,7 @@ export default function createOptionsForTaskType(config, task) {
     Object.assign(importToGlobal, {
       react: 'wp.element',
       'react-dom': 'wp.element',
+      'react/jsx-runtime': 'ReactJSXRuntime'
     })
 
     /**

--- a/task/js.js
+++ b/task/js.js
@@ -314,7 +314,7 @@ export default function createOptionsForTaskType(config, task) {
         target: 'es2020', // default, or 'es20XX', 'esnext'
 
         sourceMap: true,
-        minify: !isDev && !isEsModule,
+        minify: task.minify ?? (!isDev && !isEsModule),
 
         // Optionally preserve symbol names during minification
         // https://esbuild.github.io/api/#keep-names

--- a/task/js.js
+++ b/task/js.js
@@ -91,12 +91,13 @@ export default function createOptionsForTaskType(config, task) {
       values[key] =
         task.replaceStrings[key] instanceof Function
           ? () => JSON.stringify(task.replaceStrings[key]())
-          : JSON.stringify(task.replaceStrings[key])
+          : task.replaceStrings[key]
     }
   }
 
   const replaceStrings = {
     // Silence warning from plugin about default value (true) in next version
+    include: task.replaceInclude,
     preventAssignment: true,
     values,
   }

--- a/test/src/test/convert.ts
+++ b/test/src/test/convert.ts
@@ -1,0 +1,18 @@
+
+// replaceStrings
+
+const buildTimeValues = {
+  date: __buildDate__,
+  version: __buildVersion__
+}
+
+console.log('Build time', buildTimeValues)
+
+// replaceCode
+
+const runTimeValues = {
+  date: __currentDate__,
+  version: __currentVersion__
+}
+
+console.log('Run time', runTimeValues)

--- a/test/tangible.config.js
+++ b/test/tangible.config.js
@@ -12,6 +12,21 @@ module.exports = {
       react: 'preact', // react, preact, wp
     },
     {
+      src: 'src/test/convert.ts',
+      dest: 'build/test/convert.js',
+      minify: false,
+      replaceStrings: {
+        'process.env.NODE_ENV': 'production',
+        __buildDate__: () => new Date(),
+        __buildVersion__: 15
+      },
+      replaceCode: {
+        'process.env.NODE_ENV': '"production"',
+        __currentDate__: 'new Date()',
+        __currentVersion__: '15'
+      },
+    },
+    {
       src: 'src/index.jsx',
       dest: 'build/with-preact-window.min.js',
       react: 'window.Tangible.Preact',


### PR DESCRIPTION
This PR changes the way Roller handles `replace` entries from each task object:

- Adds a possibility to use an array of `include` paths. This allows the consumer to define what dependencies inside `node_modules` need to be included in the replace plugin scope.
- Removes `JSON` string escaping in case it's not a function.

I don't know if you'll agree to this approach, because the JSON escaping thing has been there for a reason. But I have found that it breaks replace functionality with this use case at least:

```js
    {
      src: "assets/src/js/admin/view-editor.jsx",
      dest: "assets/build/view-editor.min.js",
      react: "wp", // Using WordPress shipped React instead of bundling
      "react-dom": "wp",
      replaceStrings: {
        "import { jsxs, Fragment, jsx } from 'react/jsx-runtime';": "import React from 'react';",
        "import { jsx, jsxs, Fragment } from 'react/jsx-runtime';": "import React from 'react';",
        "import {jsxs, Fragment, jsx} from 'react/jsx-runtime';": "import React from 'react';",
        // Replace the JSX function calls
        'jsxs(': 'React.createElement(',
        'jsx(': 'React.createElement(',
        // Handle Fragment usage
        'Fragment,': 'React.Fragment,',
        'Fragment }': 'React.Fragment }'
      },
      replaceInclude: [
        'node_modules/flowbite-react-icons/**'
      ]
    },
```

Perhaps we can just allow the consumer to provide their own rollup config that will get extended by Roller?